### PR TITLE
Change mention of SVG-in-OpenType to OpenType-SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Firefox (on OSX?) has a bug that prevents color glyphs from being used on `canva
 
 Include `chromacheck-min.js` in your page and it'll add classes to the `html` element for each supported color format:
 
-* `chromacheck-svg` if there's support for SVG-in-OpenType.
+* `chromacheck-svg` if there's support for OpenType-SVG.
 * `chromacheck-colr` if there's support for COLR/CPAL.
 * `chromacheck-sbix` if there's support for Apple SBIX.
 * `chromacheck-cbdt` if there's support for CBDT/CBLC.

--- a/chromacheck.js
+++ b/chromacheck.js
@@ -29,7 +29,7 @@
     res.cbdt = context.getImageData(10, 10, 1, 1).data[0] === 100; // CBDT/CBLC
     res.colr = context.getImageData(10, 30, 1, 1).data[0] === 200; // COLR/CPAL
     res.sbix = context.getImageData(10, 50, 1, 1).data[0] === 150; // SBIX
-    res.svg  = context.getImageData(10, 70, 1, 1).data[0] === 50;  // SVG-in-OpenType
+    res.svg  = context.getImageData(10, 70, 1, 1).data[0] === 50;  // OpenType-SVG
 
     // Add class to HTML tag for each supported color format
     for (var key in res) {

--- a/demo.html
+++ b/demo.html
@@ -49,7 +49,7 @@
 
         <div class="sbix">Apple SBIX is <strong>not</strong> supported</div>
         <div class="colr">COLR/CPAL is <strong>not</strong> supported</div>
-        <div class="svg">SVG-in-OpenType is <strong>not</strong> supported</div>
+        <div class="svg">OpenType-SVG is <strong>not</strong> supported</div>
         <div class="cbdt">CBDT/CBLC is <strong>not</strong> supported</div>
 
         <p>


### PR DESCRIPTION
Hey!

To avoid any confusion I think it's better to say `OpenType-SVG` as everyone is using that one now! 😉 ("The final official name", it's also used as `OT-SVG`)